### PR TITLE
dos_detector.rbの変数hostを削除

### DIFF
--- a/dos_detector/dos_detector.rb
+++ b/dos_detector/dos_detector.rb
@@ -2,7 +2,6 @@ Server = get_server_class
 r = Server::Request.new
 cache = Userdata.new.shared_cache
 global_mutex = Userdata.new.shared_mutex
-host = r.hostname
 
 config = {
   :counter_key => r.hostname,


### PR DESCRIPTION
dos_detector.rbの変数host
`
host = r.hostname
`
がどこにも使われていませんでしたので、削除しました。
確認お願いします。